### PR TITLE
Latency issues

### DIFF
--- a/client/src/components/pages/demo/track/Track.js
+++ b/client/src/components/pages/demo/track/Track.js
@@ -114,7 +114,11 @@ export const Track = ({ track, playingState, tracksState, demo }) => {
 
   const startRecording = () => {
     try {
-      Tone.Transport.seconds = - (Tone.Transport.context._context._nativeAudioContext.outputLatency + .02);
+      //Only Firefox has this property on AudioContext, so it will only be in sync for Firefox
+      //This is a temporary fix, hopefully we find a way to sync on all browsers soon
+      if (Tone.Transport.context._context._nativeAudioContext.outputLatency + .02) {
+        Tone.Transport.seconds = - (Tone.Transport.context._context._nativeAudioContext.outputLatency + .02);
+      }
       setRecording(true);
       setPlaying(true);
       recorder.start();

--- a/client/src/components/pages/demo/track/Track.js
+++ b/client/src/components/pages/demo/track/Track.js
@@ -114,9 +114,10 @@ export const Track = ({ track, playingState, tracksState, demo }) => {
 
   const startRecording = () => {
     try {
-      recorder.start();
+      Tone.Transport.seconds = - (Tone.Transport.context._context._nativeAudioContext.outputLatency + .02);
       setRecording(true);
-      setPlaying(true)
+      setPlaying(true);
+      recorder.start();
     } catch (err) {
       setError(err.message);
     }


### PR DESCRIPTION
### Changes:

- At the start of recording, the Tone.Transport's initial "seconds" value is set to the negative value of the AudioContext's outputLatency property. This _seems_ to fix sync issues on Firefox in tests, I'm sure there will still be issues depending on the user's machine/microphone, etc. This is just a temporary fix as it only works on Firefox. If the user is not on Firefox, the Transport's time will not be set back and there will be noticable latency.