### PR TITLE
Added %PUBLIC_URL% to favicon location to fix issue #29

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Send a Demo</title>
-    <link rel="icon" href="./SAD.png" />
-    <link rel="apple-touch-icon" sizes="128x128" href="./SAD.png" />
+    <link rel="icon" href="%PUBLIC_URL%/SAD.png" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
Changes:

- Added `%PUBLIC_URL%` to favicon path to fix requests to the server looking for the image on route change/reload (fixes issue #29).
- Removed apple-touch-icon from index.html, there is no reason to have it right now (recording is out of sync on iOS currently).