### PR TITLE
Can now login with username or email

### DIFF
--- a/client/src/components/pages/login/Login.js
+++ b/client/src/components/pages/login/Login.js
@@ -8,7 +8,8 @@ import { Form, FormInput } from "components/reusable/form/Form";
 
 export default function Login() {
 
-  const [email, setEmail] = useState("");
+  // loginIdentifier is the user's email or username
+  const [loginIdentifier, setLoginIdentifier] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState(null)
 
@@ -17,12 +18,12 @@ export default function Login() {
 
   const submit = async () => {
 
-    if (email === "" || password === "") {
-      return setError("Email and Password are required");
+    if (loginIdentifier === "" || password === "") {
+      return setError("All Fields Required");
     }
 
     try {
-      const loginUser = { email, password };
+      const loginUser = { loginIdentifier, password };
       const { data: loginRes } = await Axios.post("/users/login", loginUser);
       setUser(loginRes.user);
       localStorage.setItem("auth-token", loginRes.token);
@@ -35,7 +36,7 @@ export default function Login() {
   return (
     <Form title="Login" onSubmit={submit}>
 
-      <FormInput name="email" type="email" label="Email" onChange={setEmail} autoFocus />
+      <FormInput name="loginIdentifier" label="Email or Username" onChange={setLoginIdentifier} autoFocus />
       <FormInput name="password" type="password" label="Password" onChange={setPassword} />
 
       <div className="center">

--- a/server/routes/user.router.js
+++ b/server/routes/user.router.js
@@ -10,9 +10,8 @@ router.post("/register", (req, res) => {
 });
 
 router.post("/login", (req, res) => {
-    // email will be updated to something like `loginIdentifier` to accomodate email OR username in future
-    const { email, password } = req.body;
-    respond(res, () => serv.loginUser(email, password));
+    const { loginIdentifier, password } = req.body;
+    respond(res, () => serv.loginUser(loginIdentifier, password));
 });
 
 router.delete("/delete", auth, (req, res) => {

--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -43,12 +43,20 @@ const loginUser = async (loginIdentifier, password) => {
         error("All Fields Required");
     }
 
-    const foundUser = await User.findOne({ email: loginIdentifier }, { __v: 0 });
-    const { password: foundPassword, ...user} = foundUser.toObject();
+    let foundUser = null;
 
-    if (!user) {
-        error("No account with this email has been found", 400);
+    // a simple regex test to see if the loginIdentifier matches the following: anystring@anystring.anystring
+    if (/\S+@\S+\.\S+/.test(loginIdentifier)) {
+        foundUser = await User.findOne({ email: loginIdentifier }, { __v: 0 });
+    } else {
+        foundUser = await User.findOne({ userName: loginIdentifier }, { __v: 0 });
     }
+
+    if (!foundUser) {
+        error("No account with this email or username", 400);
+    }
+
+    const { password: foundPassword, ...user} = foundUser.toObject();
 
     const isMatch = await bcrypt.compare(password, foundPassword);
     if (!isMatch) error("Invalid Credentials", 400);


### PR DESCRIPTION
Pretty straightforward stuff. Changed the login prompt to be "Email or Username" rather than just "Email". I refer to this new login string that could be the email or username as the "loginIdentifier". 

On the back-end, I just do a simple regex test to check if the loginIdentifier takes the form of an email or not to determine how to query the DB.