### PR TITLE
Fixes to track behavior

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,7 +17,6 @@ import "style.css";
 export default function App() { 
 
   const { user, loading } = useContext(UserContext);
-  console.log(user);
 
   if (loading) return null;
   return (

--- a/client/src/components/pages/demo/Demo.js
+++ b/client/src/components/pages/demo/Demo.js
@@ -16,7 +16,7 @@ export default function Demo({ location }) {
   Tone.start();
   const [showNewTrack, setShowNewTrack] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
-  const { demo, error, demoLoading, tracks, tracksLoading, setTracks, setError, demoLength } = useDemo(
+  const { demo, error, demoLoading, tracks, tracksLoading, setTracks, setError, lengthState: [trackLengths, setTrackLengths], demoLength } = useDemo(
     location.state
   );
   const [playing, setPlaying] = useState(false);
@@ -67,6 +67,7 @@ export default function Demo({ location }) {
               track={t}
               demo={demo}
               demoLength={demoLength}
+              lengthState={[trackLengths, setTrackLengths]}
               playingState={[playing, setPlaying]}
               timeState={[currentTime, setCurrentTime]}
               tracksState={[tracks, setTracks]}

--- a/client/src/components/pages/demo/useDemo.js
+++ b/client/src/components/pages/demo/useDemo.js
@@ -9,9 +9,10 @@ export const useDemo = (locationState) => {
   const [demo, setDemo] = useState(null);
   const [tracks, setTracks] = useState([]);
   const [error, setError] = useState(null);
-  const [demoLength, setDemoLength] = useState(null);
+  const [trackLengths, setTrackLengths] = useState(null);
   const [demoLoading, setDemoLoading] = useState(true);
   const [tracksLoading, setTracksLoading] = useState(true);
+  const [demoLength, setDemoLength] = useState(null);
   const { demoId } = useParams();
 
 
@@ -55,7 +56,7 @@ export const useDemo = (locationState) => {
 
         setDemo(currentDemo);
         setDemoLoading(false);
-        let trackLengths = [];
+        let initTrackLengths = [];
         const currentTracks = await Promise.all(
           currentDemo.tracks.map(async (track) => {
             let player = null;
@@ -63,17 +64,18 @@ export const useDemo = (locationState) => {
               player = await new Promise((resolve, reject) => {
                 const p = new Tone.Player(track.trackSignedURL, () => {
                   if (p) {
-                    trackLengths.push(p.buffer.duration);
+                    if (!track.trackStart) track.trackStart = 0;
+                    initTrackLengths.push({id: track._id, length: p.buffer.duration + track.trackStart});
                     resolve(p.sync().start(0).toDestination());
                   } else reject(new Error(`Could not create track from track signed url ${track.trackSignedURL}`));
                 });
               });
             }
-
+            setTrackLengths([...initTrackLengths]);
             return { ...track, player };
           })
         );
-        setDemoLength(Math.max(...trackLengths));
+
         setTracks(currentTracks);
         setTracksLoading(false);
         setError(null);
@@ -87,6 +89,22 @@ export const useDemo = (locationState) => {
     })();
   }, [locationState, demoId]);
 
+  //sets demo length when trackLengths is modified
+  useEffect(() => {
+    let longestTrack = {id: null, length: 0};
+    if (trackLengths) {
+      setDemoLength(() => {
+        trackLengths.forEach(t => {
+          if (t.length > longestTrack.length) {
+            longestTrack = {id: t.id, length: t.length}
+          }
+        })
+        return longestTrack.length;
+      });
+      //Stopping the Transport after setting demoLength, the demo would not play if I didn't do this
+      Tone.Transport.stop();
+    }
+  }, [trackLengths, setDemoLength])
 
   return {
     demo,
@@ -95,6 +113,7 @@ export const useDemo = (locationState) => {
     demoLoading,
     tracksLoading,
     setTracks,
-    demoLength,
+    lengthState: [trackLengths, setTrackLengths],
+    demoLength
   };
 };


### PR DESCRIPTION
### Changes:
Closes #27
- Added `trackLengths` to our demo's state in useDemo to hold track lengths and track IDs. When a new Tone Player is created, the track ID and player buffer duration are added to trackLengths. When a track is deleted it is removed from trackLengths.
- Added a useEffect in useDemo that updates demoLength when a track is added or removed. (This will need to be modified when track start times is added).
- Awaited the recorder in `stopRecording()`. I think the reason our audio wasn't showing up before was because the Tone Player was trying to be created before the audio file was ready.
- Removed `recorder.clear()` from the end of our `stopRecording()` function (I think that's from when we were using recorder-js, it was giving me a "is not a function" error).