### PR TITLE
Track Start Times

### DIFF
--- a/client/src/components/pages/demo/track/Track.js
+++ b/client/src/components/pages/demo/track/Track.js
@@ -61,7 +61,6 @@ export const Track = ({
         if (track.trackSignedURL) {
           // delete from aws!!!
           const { data: changedTrack } = await Axios.delete(`/demos/${demoId}/tracks/${track._id}/audio`);
-          await Axios.post("/demos/modify-track-start-time", {trackId: track._id, startTime: null});
           setTracks(
             tracks.map((t) => {
               if (t._id === track._id) {

--- a/client/src/components/pages/demo/track/Track.js
+++ b/client/src/components/pages/demo/track/Track.js
@@ -23,6 +23,7 @@ export const Track = ({
 
   const [error, setError] = useState(null);
   const [hasAudio, setHasAudio] = useState(!!track.trackSignedURL);
+  const [startTime, setStartTime] = useState(null);
   const [recording, setRecording] = useState(false);
   const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
@@ -60,6 +61,7 @@ export const Track = ({
         if (track.trackSignedURL) {
           // delete from aws!!!
           const { data: changedTrack } = await Axios.delete(`/demos/${demoId}/tracks/${track._id}/audio`);
+          await Axios.post("/demos/modify-track-start-time", {trackId: track._id, startTime: null});
           setTracks(
             tracks.map((t) => {
               if (t._id === track._id) {
@@ -105,7 +107,8 @@ export const Track = ({
       });
 
       await Axios.post(`/demos/add-signed-url`, { trackId: track._id, url }, { headers: { "x-auth-token": token } });
-
+      // sending request to update track start time on upload
+      await Axios.post("/demos/modify-track-start-time", {trackId: track._id, startTime: startTime});
       setTracks((tracks) =>
         tracks.map((t) => {
           if (t._id === track._id) {
@@ -124,14 +127,16 @@ export const Track = ({
 
   const startRecording = () => {
     try {
+      // Setting start time of track and
+      setStartTime(currentTime);
+      recorder.start();
       //Only Firefox has this property on AudioContext, so it will only be in sync for Firefox
       //This is a temporary fix, hopefully we find a way to sync on all browsers soon
-      if (Tone.Transport.context._context._nativeAudioContext.outputLatency + .02) {
-        Tone.Transport.seconds = - (Tone.Transport.context._context._nativeAudioContext.outputLatency + .02);
+      if (Tone.Transport.context._context._nativeAudioContext.outputLatency) {
+        Tone.Transport.seconds = currentTime - (recorder.context.outputLatency * 2);
       }
       setRecording(true);
-      setPlaying(true);
-      recorder.start();
+      setPlaying(true);     
     } catch (err) {
       setError(err.message);
     }
@@ -162,7 +167,7 @@ export const Track = ({
               const player = await new Promise((resolve, reject) => {
                 const p = new Tone.Player(fileLocation, () => {
                   if (p) {
-                    resolve(p.sync().start(0).toDestination());
+                    resolve(p.sync().start(startTime).toDestination());
                   }
                   else reject(new Error(`Could not create track from file ${localFile.name}`));
                 });
@@ -170,10 +175,10 @@ export const Track = ({
               //Adds the duration of the recorded buffer to trackLengths.
               // When we add start time for tracks we will have to add that
               // to the player.buffer.duration to get the length
-              if (trackLengths) setTrackLengths([...trackLengths, {id: track._id, length: player.buffer.duration}]);
-              else setTrackLengths([{id: track._id, length: player.buffer.duration}]);
+              if (trackLengths) setTrackLengths([...trackLengths, {id: track._id, length: startTime + player.buffer.duration}]);
+              else setTrackLengths([{id: track._id, length: startTime + player.buffer.duration}]);
               player.volume.value = volume;
-              return { ...track, player };
+              return { ...track, player, trackStart: startTime };
             }
             return t;
           })

--- a/client/src/components/pages/demo/useDemo.js
+++ b/client/src/components/pages/demo/useDemo.js
@@ -63,7 +63,7 @@ export const useDemo = (locationState) => {
                   if (p) {
                     if (!track.trackStart) track.trackStart = 0;
                     initTrackLengths.push({id: track._id, length: p.buffer.duration + track.trackStart});
-                    resolve(p.sync().start(0).toDestination());
+                    resolve(p.sync().start(track.trackStart).toDestination());
                   } else reject(new Error(`Could not create track from track signed url ${track.trackSignedURL}`));
                 });
               });

--- a/server/models/trackModel.js
+++ b/server/models/trackModel.js
@@ -4,7 +4,7 @@ const trackSchema = new mongoose.Schema({
   trackTitle: { type: String, required: true },
   trackPath: { type: String, required: true },
   trackAuthor: { type: String, required: true },
-  trackStart: { type: Number, required: false },
+  trackStart: { type: Number, default: null },
   trackLength: { type: Number, required: false },
   trackVolume: { type: Number, min: 0, max: 100, required: false },
   trackSignedURL: { type: String, default: null },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "mern-auth",
+  "name": "SaD-Server",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/server/routes/demo.router.js
+++ b/server/routes/demo.router.js
@@ -29,6 +29,11 @@ router.post("/add-signed-url", auth, (req, res) => {
     respond(res, () => serv.updateTrackUrl(trackId, url));
 });
 
+router.post("/modify-track-start-time", (req, res) => {
+    const { trackId, startTime } = req.body;
+    respond(res, () => serv.modifyTrackStartTime(trackId, startTime));
+});
+
 router.put("/:demoId/addContributor/:userId", (req, res) => {
     const { demoId, userId } = req.params;
     respond(res, () => serv.addUserToDemo(demoId, userId));

--- a/server/services/demo.service.js
+++ b/server/services/demo.service.js
@@ -72,7 +72,6 @@ const updateTrackUrl = (trackId, url) => {
 }
 
 const modifyTrackStartTime = (trackId, startTime) => {
-    console.log(trackId, startTime);
     return Track.findByIdAndUpdate(trackId, { trackStart: startTime });
 }
 
@@ -96,9 +95,12 @@ const deleteTrack = async (demoId, trackId) => {
 
 const deleteTrackAudio = async (demoId, trackId) => {
     await s3.deleteFile(`${demoId}/${trackId}`);
-    const changedTrack = await updateTrackUrl(trackId, null);
+    const changedTrack = await Track.findByIdAndUpdate(trackId, {
+        trackSignedURL: null,
+        trackStart: null
+    });
 
-    return { ...changedTrack.toObject(), trackSignedURL: null };
+    return { ...changedTrack.toObject(), trackSignedURL: null, trackStart: null };
 }
 
 const addUserToDemo = async (demoId, userId) => {

--- a/server/services/demo.service.js
+++ b/server/services/demo.service.js
@@ -71,6 +71,11 @@ const updateTrackUrl = (trackId, url) => {
     return Track.findByIdAndUpdate(trackId, { trackSignedURL: url });
 }
 
+const modifyTrackStartTime = (trackId, startTime) => {
+    console.log(trackId, startTime);
+    return Track.findByIdAndUpdate(trackId, { trackStart: startTime });
+}
+
 const deleteDemoById = (demoId) => {
     return Demo.findByIdAndDelete(demoId);
 }
@@ -162,6 +167,7 @@ module.exports = {
     createDemo,
     addTrackToDemo,
     updateTrackUrl,
+    modifyTrackStartTime,
     deleteDemoById,
     deleteTrack,
     deleteTrackAudio,


### PR DESCRIPTION
Adds ability to start recording tracks wherever the user wants

**Changes:**
- Made default value for trackStart in the track model null
- Added service to modify track start time in mongodb. Added route to use service
- Added post requests on track upload and audio deletion to modify track start time
- Changed start times when syncing a Tone Player to reflect the new start times

Closes #9 