### PR TITLE
Public demos

### DIFF
--- a/client/src/components/pages/demo/Demo.js
+++ b/client/src/components/pages/demo/Demo.js
@@ -2,7 +2,7 @@ import React, { useContext, useState, useEffect } from "react";
 import { Button, IconButton } from "components/reusable/button/Button";
 import { useDemo } from "./useDemo";
 import { Track } from "./track/Track";
-import { FaPlay, FaPause } from "react-icons/fa";
+import { FaPlay, FaPause, FaRegTrashAlt } from "react-icons/fa";
 import "./demo.css";
 import ErrorNotice from "components/reusable/error/Error";
 import { Form, FormInput } from "components/reusable/form/Form";
@@ -11,8 +11,9 @@ import Axios from "axios";
 import { Popup } from "components/reusable/popup/Popup";
 import { AudioScrubber } from "components/pages/demo/Scrubber"
 import * as Tone from "tone";
-import { MdPersonAdd } from "react-icons/md";
+import { MdPersonAdd, MdSettings } from "react-icons/md";
 import { ContributorSearch } from "components/userSearch/ContributorSearch";
+import { DemoSettings } from "./DemoSettings";
 
 export default function Demo({ location }) {
   Tone.start();
@@ -23,6 +24,7 @@ export default function Demo({ location }) {
   );
   const [playing, setPlaying] = useState(false);
   const [ showSearch, setShowSearch ] = useState(false);
+  const [ showSettings, setShowSettings ] = useState(false);
 
   //Controls play/pause
   useEffect(() => {
@@ -52,8 +54,10 @@ export default function Demo({ location }) {
         <Button onClick={() => setShowNewTrack(true)}>New Track +</Button>
       </div>
 
-      <div className="center">
-        <IconButton component={MdPersonAdd} onClick={() => setShowSearch(show => !show)} style={{marginTop: "10px"}} />
+      <div className="demoControlButtonsContainer">
+        <IconButton component={FaRegTrashAlt} />
+        <IconButton component={MdPersonAdd} onClick={() => setShowSearch(show => !show)} />
+        <IconButton component={MdSettings} onClick={() => setShowSettings(show => !show)} />
       </div>
         
       <hr style={{ margin: "15px 0px" }} />
@@ -97,6 +101,8 @@ export default function Demo({ location }) {
       )}
 
       {showSearch && <ContributorSearch demo={demo} onAddContributor={onAddContributor} onExit={() => setShowSearch(false)} />}
+      
+      {showSettings && <DemoSettings demo={demo} onUpdateDemo={updatedDemo => setDemo(updatedDemo)} onExit={() => setShowSettings(false)} />}
     </div>
   );
 }

--- a/client/src/components/pages/demo/DemoSettings.js
+++ b/client/src/components/pages/demo/DemoSettings.js
@@ -1,24 +1,60 @@
+import Axios from 'axios';
 import { Button } from 'components/reusable/button/Button';
 import { Form, FormCheckBox, FormInput } from 'components/reusable/form/Form';
 import { Popup } from 'components/reusable/popup/Popup';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
-export const DemoSettings = ({demo, onExit}) => {
+export const DemoSettings = ({demo, onExit, onUpdateDemo}) => {
 
     const [ title, setTitle ] = useState(demo.title);
-    const [ isPublic, setIsPublic ]= useState(demo.isPublic);
+    const [ isPublic, setIsPublic ] = useState(demo.isPublic);
+    const [ error, setError ] = useState(null);
+    const [ notice, setNotice ] = useState(null);
     
-    const submit = () => {
+    const timeoutRef = useRef();
 
+    // useEffect that removes the error/notice after 4 seconds of appearing
+    useEffect(() => {
+        timeoutRef.current = setTimeout(() => {
+            setError(null);
+            setNotice(null);
+        }, 4000);
+
+        return () => clearTimeout(timeoutRef.current);
+    }, [error, notice]);
+   
+
+    const submit = async () => {
+        try {
+
+            if (!title) { return setError("Title is required"); }
+
+            if (title === demo.title && isPublic === demo.isPublic) {
+                return setError("You didn't change anything");
+            }
+
+            const { data: updatedDemo } = await Axios.put(`/demos/${demo._id}/update`, {
+                title,
+                isPublic
+            });
+
+            onUpdateDemo(updatedDemo);
+
+            setNotice("Successfully Updated Demo");
+        } catch (err) {
+            err.response && setError(err.response.data.error);
+        }
     }
 
     return (
         <Popup title={demo.title} onExit={onExit}>
+            {error && <div>{error}</div>}
+            {notice && <div>{notice}</div>}
             <Form onSubmit={submit}>
                 <FormInput name="title" label="Demo Title" value={title} onChange={e => setTitle(e.target.value)} autoFocus />
-                <FormCheckBox type="checkbox" name="public" label="Public" checked={isPublic} onChange={e => setIsPublic(p => !p)} />
+                <FormCheckBox type="checkbox" name="isPublic" label="Public" checked={isPublic} onChange={e => setIsPublic(p => !p)} />
             
-                <div style={{display: "flex"}}>
+                <div className="center">
                     <Button type="submit">Submit Changes</Button>
                 </div>
             </Form>

--- a/client/src/components/pages/demo/DemoSettings.js
+++ b/client/src/components/pages/demo/DemoSettings.js
@@ -1,0 +1,27 @@
+import { Button } from 'components/reusable/button/Button';
+import { Form, FormCheckBox, FormInput } from 'components/reusable/form/Form';
+import { Popup } from 'components/reusable/popup/Popup';
+import React, { useState } from 'react';
+
+export const DemoSettings = ({demo, onExit}) => {
+
+    const [ title, setTitle ] = useState(demo.title);
+    const [ isPublic, setIsPublic ]= useState(demo.isPublic);
+    
+    const submit = () => {
+
+    }
+
+    return (
+        <Popup title={demo.title} onExit={onExit}>
+            <Form onSubmit={submit}>
+                <FormInput name="title" label="Demo Title" value={title} onChange={e => setTitle(e.target.value)} autoFocus />
+                <FormCheckBox type="checkbox" name="public" label="Public" checked={isPublic} onChange={e => setIsPublic(p => !p)} />
+            
+                <div style={{display: "flex"}}>
+                    <Button type="submit">Submit Changes</Button>
+                </div>
+            </Form>
+        </Popup>
+    );
+}

--- a/client/src/components/pages/demo/DemoSettings.js
+++ b/client/src/components/pages/demo/DemoSettings.js
@@ -52,7 +52,7 @@ export const DemoSettings = ({demo, onExit, onUpdateDemo}) => {
             {notice && <div>{notice}</div>}
             <Form onSubmit={submit}>
                 <FormInput name="title" label="Demo Title" value={title} onChange={e => setTitle(e.target.value)} autoFocus />
-                <FormCheckBox type="checkbox" name="isPublic" label="Public" checked={isPublic} onChange={e => setIsPublic(p => !p)} />
+                <FormCheckBox name="isPublic" label="Public" checked={isPublic} onChange={e => setIsPublic(p => !p)} />
             
                 <div className="center">
                     <Button type="submit">Submit Changes</Button>

--- a/client/src/components/pages/demo/demo.css
+++ b/client/src/components/pages/demo/demo.css
@@ -11,3 +11,13 @@
   text-align: center;
 }
 
+.demoControlButtonsContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 10px;
+}
+
+.demoControlButtonsContainer * {
+  margin: 0px 5px;
+}

--- a/client/src/components/pages/myDemos/DemoItem.js
+++ b/client/src/components/pages/myDemos/DemoItem.js
@@ -21,7 +21,7 @@ export const DemoItem = ({demo, setDemos}) => {
         });
     }
 
-    const onAddContributor = (updatedDemo) => {
+    const updateDemos = (updatedDemo) => {
         setDemos(demos => demos.map(d => {
             if (d._id === demo._id) {
                 return updatedDemo;
@@ -46,8 +46,8 @@ export const DemoItem = ({demo, setDemos}) => {
                 <IconButton component={MdSettings} onClick={() => setShowSettings(show => !show)} style={{marginTop: "10px"}}/>
             </div>}
 
-            {showSearch && <ContributorSearch demo={demo} onAddContributor={onAddContributor} onExit={() => setShowSearch(false)} />}
-            {showSettings && <DemoSettings demo={demo} onExit={() => setShowSettings(false)} />}
+            {showSearch && <ContributorSearch demo={demo} onAddContributor={updateDemos} onExit={() => setShowSearch(false)} />}
+            {showSettings && <DemoSettings demo={demo} onUpdateDemo={updateDemos} onExit={() => setShowSettings(false)} />}
         </div>
     )
 }

--- a/client/src/components/pages/myDemos/DemoItem.js
+++ b/client/src/components/pages/myDemos/DemoItem.js
@@ -1,9 +1,10 @@
 import { IconButton } from 'components/reusable/button/Button';
+import { Popup } from 'components/reusable/popup/Popup';
 import { ContributorSearch } from 'components/userSearch/ContributorSearch';
 import UserContext from 'context/UserContext';
 import React, { useContext, useState } from 'react';
 import { FaRegTrashAlt } from 'react-icons/fa';
-import { MdPersonAdd } from 'react-icons/md';
+import { MdPersonAdd, MdSettings } from 'react-icons/md';
 import { useHistory } from 'react-router-dom';
 
 export const DemoItem = ({demo, setDemos}) => {
@@ -11,6 +12,7 @@ export const DemoItem = ({demo, setDemos}) => {
     const history = useHistory();
     const { user } = useContext(UserContext);
     const [ showSearch, setShowSearch ] = useState(false);
+    const [ showSettings, setShowSettings ] = useState(false);
     
     const demoClick = () => {
         history.push({
@@ -41,9 +43,11 @@ export const DemoItem = ({demo, setDemos}) => {
             {user._id === demo.creator._id && <div className="demoItemControls">
                 <IconButton component={FaRegTrashAlt} />
                 <IconButton component={MdPersonAdd} onClick={() => setShowSearch(show => !show)} style={{marginTop: "10px"}} />
+                <IconButton component={MdSettings} onClick={() => setShowSettings(show => !show)} style={{marginTop: "10px"}}/>
             </div>}
 
             {showSearch && <ContributorSearch demo={demo} onAddContributor={onAddContributor} onExit={() => setShowSearch(false)} />}
+            {showSettings && <Popup title={demo.title} onExit={() => setShowSettings(false)}></Popup>}
         </div>
     )
 }

--- a/client/src/components/pages/myDemos/DemoItem.js
+++ b/client/src/components/pages/myDemos/DemoItem.js
@@ -1,11 +1,11 @@
 import { IconButton } from 'components/reusable/button/Button';
-import { Popup } from 'components/reusable/popup/Popup';
 import { ContributorSearch } from 'components/userSearch/ContributorSearch';
 import UserContext from 'context/UserContext';
 import React, { useContext, useState } from 'react';
 import { FaRegTrashAlt } from 'react-icons/fa';
 import { MdPersonAdd, MdSettings } from 'react-icons/md';
 import { useHistory } from 'react-router-dom';
+import { DemoSettings } from '../demo/DemoSettings';
 
 export const DemoItem = ({demo, setDemos}) => {
 
@@ -47,7 +47,7 @@ export const DemoItem = ({demo, setDemos}) => {
             </div>}
 
             {showSearch && <ContributorSearch demo={demo} onAddContributor={onAddContributor} onExit={() => setShowSearch(false)} />}
-            {showSettings && <Popup title={demo.title} onExit={() => setShowSettings(false)}></Popup>}
+            {showSettings && <DemoSettings demo={demo} onExit={() => setShowSettings(false)} />}
         </div>
     )
 }

--- a/client/src/components/pages/myDemos/NewDemo.js
+++ b/client/src/components/pages/myDemos/NewDemo.js
@@ -4,13 +4,14 @@ import { useHistory } from "react-router-dom";
 import UserContext from "context/UserContext";
 import ErrorNotice from "components/reusable/error/Error";
 import { Button } from "components/reusable/button/Button";
-import { Form, FormInput } from "components/reusable/form/Form";
+import { Form, FormCheckBox, FormInput } from "components/reusable/form/Form";
 
 export default function CreateDemo() {
   const { user } = useContext(UserContext);
   const history = useHistory();
 
   const [demoTitle, setDemoTitle] = useState("");
+  const [isPublic, setIsPublic] = useState(false);
   const [error, setError] = useState(null);
 
   const submit = async (e) => {
@@ -20,7 +21,8 @@ export default function CreateDemo() {
     try {
       const newDemoRes = await Axios.post("/demos/new-demo", {
         creatorId: user._id,
-        title: demoTitle
+        title: demoTitle,
+        isPublic
       });
       
       history.push(`/demos/${newDemoRes.data._id}`);
@@ -30,8 +32,9 @@ export default function CreateDemo() {
   };
 
   return (
-    <Form title="New Demo Title" onSubmit={submit}>
-      <FormInput name="demoTitle" onChange={e => setDemoTitle(e.target.value)} autoFocus />
+    <Form title="New Demo" onSubmit={submit}>
+      <FormInput name="demoTitle" label="Title" onChange={e => setDemoTitle(e.target.value)} autoFocus />
+      <FormCheckBox name="isPublic" label="Public" checked={isPublic} onChange={e => setIsPublic(p => !p)} />
       <div className="center">
         <Button type="submit">Create New Demo</Button>
       </div>

--- a/client/src/components/pages/myDemos/myDemos.css
+++ b/client/src/components/pages/myDemos/myDemos.css
@@ -15,6 +15,10 @@
   border-radius: 15px;
 }
 
+.demoItem:last-of-type {
+  margin-bottom: 20px;
+}
+
 .demoItemInfo {
   flex: 1;
   cursor: pointer;

--- a/client/src/components/reusable/form/Form.js
+++ b/client/src/components/reusable/form/Form.js
@@ -31,7 +31,9 @@ export const FormInput = ({name, label, ...rest}) => (
 
 export const FormCheckBox = ({name, label, ...rest}) => (
     <div className="formCheckBoxContainer">
-        <label htmlFor={name}>{label}</label>
-        <input className="formCheckBox" type="checkbox" {...rest} />
+        <label htmlFor={name}>
+            {label}
+        </label>
+        <input type="checkbox" id={name} {...rest} />
     </div>
 )

--- a/client/src/components/reusable/form/Form.js
+++ b/client/src/components/reusable/form/Form.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import UnderlinedTextInput from '../inputs/Inputs';
+import { UnderlinedTextInput } from '../inputs/Inputs';
 import './form.css';
 
 export const Form = ({onSubmit, title, ...rest}) => {
@@ -27,4 +27,11 @@ export const FormInput = ({name, label, ...rest}) => (
             {...rest}
         />
     </>    
+)
+
+export const FormCheckBox = ({name, label, ...rest}) => (
+    <div className="formCheckBoxContainer">
+        <label htmlFor={name}>{label}</label>
+        <input className="formCheckBox" type="checkbox" {...rest} />
+    </div>
 )

--- a/client/src/components/reusable/form/form.css
+++ b/client/src/components/reusable/form/form.css
@@ -13,11 +13,9 @@
 }
 
 .formCheckBoxContainer {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    margin-bottom: 1.5rem;
 }
 
-.formCheckBox{
-    margin-bottom: 1.5rem;
+.formCheckBoxContainer input {
+    margin-left: 5px;
 }

--- a/client/src/components/reusable/form/form.css
+++ b/client/src/components/reusable/form/form.css
@@ -11,3 +11,13 @@
     flex-direction: column;
     justify-content: center;
 }
+
+.formCheckBoxContainer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.formCheckBox{
+    margin-bottom: 1.5rem;
+}

--- a/client/src/components/reusable/inputs/Inputs.js
+++ b/client/src/components/reusable/inputs/Inputs.js
@@ -2,8 +2,7 @@ import React from "react";
 import "./inputs.css";
 
 export const UnderlinedTextInput = (props) => {
-
-
+  
   return (
     <div>
       <input
@@ -14,5 +13,3 @@ export const UnderlinedTextInput = (props) => {
     </div>
   );
 };
-
-export default UnderlinedTextInput;

--- a/client/src/components/userSearch/UserSearch.js
+++ b/client/src/components/userSearch/UserSearch.js
@@ -1,4 +1,4 @@
-import UnderlinedTextInput from 'components/reusable/inputs/Inputs';
+import { UnderlinedTextInput } from 'components/reusable/inputs/Inputs';
 import React, { useState } from "react";
 import { useUserSearch } from './useUserSearch';
 import './userSearch.css';

--- a/server/routes/demo.router.js
+++ b/server/routes/demo.router.js
@@ -14,8 +14,8 @@ router.get("/:demoId", (req, res) => {
 });
 
 router.post("/new-demo", (req, res) => {
-    let { creatorId, title } = req.body;
-    respond(res, () => serv.createDemo(creatorId, title));
+    let { creatorId, title, isPublic } = req.body;
+    respond(res, () => serv.createDemo(creatorId, title, isPublic));
 });
 
 router.post("/:demoId/new-track", (req, res) => {

--- a/server/routes/demo.router.js
+++ b/server/routes/demo.router.js
@@ -34,6 +34,13 @@ router.put("/:demoId/addContributor/:userId", (req, res) => {
     respond(res, () => serv.addUserToDemo(demoId, userId));
 });
 
+router.put("/:demoId/update", (req, res) => {
+    const { demoId } = req.params;
+    const { title, isPublic } = req.body;
+
+    respond(res, () => serv.updateDemo(demoId, title, isPublic));
+});
+
 router.delete("/:demoId", (req, res) => {
     const { demoId } = req.params;
     respond(res, () => serv.deleteDemoById(demoId));

--- a/server/services/demo.service.js
+++ b/server/services/demo.service.js
@@ -41,12 +41,12 @@ const getDemoById = async (demoId) => {
     };    
 }
 
-const createDemo = (creatorId, title) => {
+const createDemo = (creatorId, title, isPublic) => {
     if (!title || !creatorId) {
         error('Demo must have a title and creator');
     }
 
-    return new Demo({ creatorId, title }).save();
+    return new Demo({ creatorId, title, isPublic }).save();
 }
 
 const addTrackToDemo = async (demoId, trackTitle, trackAuthor) => {

--- a/server/services/demo.service.js
+++ b/server/services/demo.service.js
@@ -111,10 +111,23 @@ const addUserToDemo = async (demoId, userId) => {
 
     const { creatorId: creator, ...demo } = pushDemo.toObject();
 
-    return {
-        ...demo,
-        creator
-    }; 
+    return { ...demo, creator }; 
+}
+
+// updates a demos title and isPublic status
+const updateDemo = async (demoId, title, isPublic) => {
+
+    const updatedDemo = await Demo.findByIdAndUpdate(demoId, {
+        title, isPublic
+    }, { new: true })
+    .populate({ path: "tracks", model: Track })
+    .populate({ path: "creatorId", model: User, select: '-__v -password'});
+
+    if (!updatedDemo) { error("Couldn't update demo"); }
+
+    const { creatorId: creator, ...demo } = updatedDemo.toObject();
+
+    return { ...demo, creator };
 }
 
 // a helper function that gets demos, lets us pass in a custom mongo $match to filter
@@ -165,5 +178,6 @@ module.exports = {
     deleteDemoById,
     deleteTrack,
     deleteTrackAudio,
-    addUserToDemo
+    addUserToDemo,
+    updateDemo
 }


### PR DESCRIPTION
Closes #15 

Created a `DemoSettings` component in the `Demo` folder of the client. This just allows the user to update a demos changeable features, including the `isPublic` attribute which is directly related to this issue. 

Added a `public` checkbox to the `/new-demo` route so a user can decide if a demo is public at the time of creation.

Added a cog button to the `DemoItem` and `Demo` components that the user can click to open the `DemoSettings` and change the demo title or isPublic attribute. I think the look of the buttons on the `DemoItem` and `Demo` should probably be changed, but they get the job done for now.

Added a new reusable `FormCheckBox` component which just puts a label and checkbox together inline.

Created a new backend service called `updateDemo` which simply updates a demo's `title` and `isPublic` by the demo's id.

Created a new demo `PUT` route at `/demos/:demoId/update` to handle updating the demo.