### PR TITLE
Fixed Regex Issue

### DIFF
--- a/client/src/components/userSearch/useUserSearch.js
+++ b/client/src/components/userSearch/useUserSearch.js
@@ -15,9 +15,7 @@ export const useUserSearch = (search, filter) => {
 
         clearTimeout(timeoutRef.current);
         
-        // a single trailing dot gets removed from the API endpoint, resulting in a GET request to `/users/search/` which is the wrong endpoint
-        // two trailing dots goes removes the `/search` part of the route and makes a GET request to `/users/` which is the wrong endpoint
-        if (!search || search === '.' || search === '..') {
+        if (!search) {
             setLoading(false);
             return;
         }
@@ -26,7 +24,9 @@ export const useUserSearch = (search, filter) => {
         
         timeoutRef.current = setTimeout(() => {
             // encode the URI component so special URL characters like `#` or `%` don't affect the URL
-            Axios.get(`/users/search/${encodeURIComponent(search)}/`)
+            Axios.get(`/users/search`, {
+                params: { userName: search }
+            })
             .then(res => {
                 
                 // if a filter function was passed in, apply it to the data

--- a/client/src/components/userSearch/useUserSearch.js
+++ b/client/src/components/userSearch/useUserSearch.js
@@ -15,15 +15,18 @@ export const useUserSearch = (search, filter) => {
 
         clearTimeout(timeoutRef.current);
         
-        if (!search) {
+        // a single trailing dot gets removed from the API endpoint, resulting in a GET request to `/users/search/` which is the wrong endpoint
+        // two trailing dots goes removes the `/search` part of the route and makes a GET request to `/users/` which is the wrong endpoint
+        if (!search || search === '.' || search === '..') {
             setLoading(false);
-            return; 
+            return;
         }
         
         setLoading(true);
         
         timeoutRef.current = setTimeout(() => {
-            Axios.get(`/users/search/${search}`)
+            // encode the URI component so special URL characters like `#` or `%` don't affect the URL
+            Axios.get(`/users/search/${encodeURIComponent(search)}/`)
             .then(res => {
                 
                 // if a filter function was passed in, apply it to the data

--- a/client/src/components/userSearch/useUserSearch.js
+++ b/client/src/components/userSearch/useUserSearch.js
@@ -23,7 +23,7 @@ export const useUserSearch = (search, filter) => {
         setLoading(true);
         
         timeoutRef.current = setTimeout(() => {
-            // encode the URI component so special URL characters like `#` or `%` don't affect the URL
+            
             Axios.get(`/users/search`, {
                 params: { userName: search }
             })

--- a/server/routes/user.router.js
+++ b/server/routes/user.router.js
@@ -22,14 +22,14 @@ router.get("/", auth, (req, res) => {
     respond(res, () => serv.getUserById(req.user));
 });
 
+router.get("/search", (req, res) => {
+    const { userName } = req.query;
+    respond(res, () => serv.searchUsers(userName));
+});
+
 router.get("/:userName", (req, res) => {
     const { userName } = req.params;
     respond(res, () => serv.getUserByUserName(userName));
-});
-
-router.get("/search/:userName", (req, res) => {
-    const { userName } = req.params;
-    respond(res, () => serv.searchUsers(userName));
 });
 
 router.get("/:userName/followers", (req, res) => {

--- a/server/routes/user.router.js
+++ b/server/routes/user.router.js
@@ -27,9 +27,9 @@ router.get("/:userName", (req, res) => {
     respond(res, () => serv.getUserByUserName(userName));
 });
 
-router.get("/search/:search", (req, res) => {
-    const { search } = req.params;
-    respond(res, () => serv.searchUsers(search));
+router.get("/search/:userName", (req, res) => {
+    const { userName } = req.params;
+    respond(res, () => serv.searchUsers(userName));
 });
 
 router.get("/:userName/followers", (req, res) => {

--- a/server/services/user.service.js
+++ b/server/services/user.service.js
@@ -140,10 +140,13 @@ const userDoesFollow = async (followerId, followeeId) => {
     return user.length !== 0; 
 }
 
-const searchUsers = async (search) => {
+const searchUsers = async (userName) => {
+
+    // escapes all special characters in a regex string
+    userName = userName.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 
     const users = await User.find(
-        { userName: { $regex: search, $options: "i"} },
+        { userName: { $regex: userName, $options: "i"} },
         { displayName: 1, userName: 1, _id: 1 }
     );
 


### PR DESCRIPTION
Closes #38

Changed the request parameter name from `search` to `userName` just to be a bit more explicit.

Escaped all special characters in the user's searched username. This just adds `\` to the front of characters that have a special meaning in JavaScript regex. For example a search like `*?sam` would become `\*\?sam`, meaning the asterisk and question mark are ignored by the regex rules.

## Edit

I fixed the period issues stated below by simply transitioning to query parameters in the url. Before, sending the username to the API looked like `GET /users/search/samstorment`. Now I've changed it to `GET /users/search?userName=samstorment`. This fixes the weird `.` and `..` issues in a way that we don't have to explicitly hard code in some if statements to make sure the search is not a `.` or `..`.

## Outdated

In `useUserSearch.js` I had to do a hacky fix to ignore a username search that is a single period or two periods. 

A single period gets dropped from the Axios request url, so a request to `/users/search/.` gets turned into `/users/search/`. Because we have the back-end route `/users/:userName`, the string `search` gets passed as the `userName`.

Two periods seems to work like the file system, where using `..` goes up to the parent directory. `..` as the route parameter like `/users/search/..`  instead makes GET request to `/users/`.

I looked for 30+ minutes for a cleaner solution to allowing periods to be used as search terms, but I settled for the sloppy solution for now. I simply added a check to see if the `search` term is `.` or `..`. If it is either, we just return. I'd like to clean this up in the future.

I tested every other standard keyboard character as well as emojis and some foreign language text and that worked fine.

The best solution will probably be sending the search term in the request body so we don't have to deal with weird URL rules. However, as far as I'm aware, GET requests can't have a request body so we'd have to use a different HTTP request type. That also seems a bit weird since GET is the appropriate HTTP request type for fetching data.