### PR TITLE
Made Email Schema Case Insensitive

### DIFF
--- a/client/src/components/pages/register/Register.js
+++ b/client/src/components/pages/register/Register.js
@@ -27,7 +27,7 @@ export default function Register() {
       const newUser = { email, password, passwordCheck, userName, displayName };
       await Axios.post("/users/register", newUser);
       const { data: loginRes } = await Axios.post("/users/login", {
-        email,
+        loginIdentifier: email,
         password,
       });
       setUser(loginRes.user);

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -1,12 +1,21 @@
 const { Schema, model } = require("mongoose");
 
 const userSchema = new Schema({
-  email: { type: String, required: true, unique: true },
+  email: { 
+    type: String,
+    trim: true, // remove front and back whitespace if it exists
+    required: "Email Address is required",
+    validate: [/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/, 'Please fill a valid email address'],
+    index: {
+      unique: true,
+      collation: { locale: 'en', strength: 2 }
+    }
+  },
   password: { type: String, required: true, minlength: 5 },
   userName: { 
     type: String, 
     required: true,
-    validate: [ /^[a-zA-Z0-9_]{0,15}$/, "Invalid Username" ],
+    match: [ /^[a-zA-Z0-9_]{0,15}$/, "Invalid Username" ],
     maxlength: 15,
     // https://stackoverflow.com/questions/13991604/mongoose-schema-validating-unique-field-case-insensitive
     index: {

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -5,7 +5,7 @@ const userSchema = new Schema({
     type: String,
     trim: true, // remove front and back whitespace if it exists
     required: "Email Address is required",
-    validate: [/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/, 'Please fill a valid email address'],
+    match: [/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/, 'Please fill a valid email address'],
     index: {
       unique: true,
       collation: { locale: 'en', strength: 2 }


### PR DESCRIPTION
Closes #33 

Updated `User` model's email. The following most important addition is the line `collation: { locale: 'en', strength: 2 }` which makes the email case insensitive. This way an email like `bob@mail.com` is a duplicate of `BOB@mail.com`.

Also made a 1 line fix to `Register.js` from a bug introduced in #32 where we switched from logging in with email only to email or username. `Register.js` was still using the `email` when we changed the name of this to `loginIdentifier` since it could represent either email or username.

Awaiting some updates to the index on the email in MongoDB to verify this works correctly before merging.