### PR TITLE
Fixed nonstop dependency updates in useUserSearch.js

### DIFF
--- a/client/src/components/userSearch/ContributorSearch.js
+++ b/client/src/components/userSearch/ContributorSearch.js
@@ -1,6 +1,6 @@
 import Axios from "axios";
 import { Popup } from "components/reusable/popup/Popup";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { UserSearch } from "./UserSearch";
 
 export const ContributorSearch = ({demo, onAddContributor, onExit}) => {
@@ -38,12 +38,13 @@ export const ContributorSearch = ({demo, onAddContributor, onExit}) => {
     }
 
     // filter out the creator and users who are already contributors
-    const filterUsers = (u) => {
+    // callback so it doesn't keep changing as demo state updates
+    const filterUsers = useCallback((u) => {
         const isCreator = u._id === demo.creator._id;
         const isContributor = demo.contributors.includes(u._id);
 
         return !isCreator && !isContributor;
-    }
+    }, [demo.contributors, demo.creator._id]);
 
     return (
         <Popup title="Add User to Demo" onExit={onExit}>

--- a/client/src/components/userSearch/useUserSearch.js
+++ b/client/src/components/userSearch/useUserSearch.js
@@ -44,6 +44,9 @@ export const useUserSearch = (search, filter) => {
             .finally(() => setLoading(false));
         }, 500);
 
+        // clear the timeout when we unmount so we don't make any unwanted Axios requests
+        return() => clearTimeout(timeoutRef.current);
+        
     }, [search, filter]);
 
     return { users, setUsers, error, loading };


### PR DESCRIPTION
Closes #42

The issue was caused by the `filterUsers` function in `ContributorSearch.js`. The function was being recreated every time there was some state update happening from a parent component (The `Demo` in this case). The `Demo` component does a lot of state updating since we set the `currentTime` state as the Tone.js Transport time moves forward.

To fix this, I just wrapped the `filterUsers` function in a `useCallback` hook. This makes it so the `filterUsers` function on gets recreated if any of its dependencies change.

Before the fix, the `filterUsers` function was getting recreated many times per second. Because we passed `filterUsers` into `useUserSearch.js`. where `filterUsers` was a `useEffect` dependecny, the `useEffect` in `useUserSearch.js` was getting re-called every time `filterUsers` was recreated. This means that the 500 millisecond timeout we set to prevent spamming our server as the user types was constantly being cleared before we could ever get close to 500 milliseconds.