### PR TITLE
Delete demo

### DIFF
--- a/client/src/components/pages/demo/Demo.js
+++ b/client/src/components/pages/demo/Demo.js
@@ -1,4 +1,5 @@
 import React, { useContext, useState, useEffect } from "react";
+import { useHistory } from 'react-router-dom';
 import { Button, IconButton } from "components/reusable/button/Button";
 import { useDemo } from "./useDemo";
 import { Track } from "./track/Track";
@@ -25,6 +26,7 @@ export default function Demo({ location }) {
   const [playing, setPlaying] = useState(false);
   const [ showSearch, setShowSearch ] = useState(false);
   const [ showSettings, setShowSettings ] = useState(false);
+  const history = useHistory();
 
   //Controls play/pause
   useEffect(() => {
@@ -38,6 +40,12 @@ export default function Demo({ location }) {
     }
   }, [currentTime, demoLength]);
 
+  const deleteDemo = async (demo) => {
+    if (window.confirm(`Are you sure you want to delete your demo "${demo.title}" ?`)) {
+      await Axios.delete(`/demos/${demo._id}`);
+      history.push('/my-demos');
+    }
+  }
 
   const onAddContributor = (updatedDemo) => {
     setDemo(updatedDemo);
@@ -68,7 +76,7 @@ export default function Demo({ location }) {
       </div>
 
       <div className="demoControlButtonsContainer">
-        <IconButton component={FaRegTrashAlt} />
+        <IconButton component={FaRegTrashAlt} onClick={() => deleteDemo(demo)} />
         <IconButton component={MdPersonAdd} onClick={() => setShowSearch(show => !show)} />
         <IconButton component={MdSettings} onClick={() => setShowSettings(show => !show)} />
       </div>

--- a/client/src/components/pages/myDemos/DemoItem.js
+++ b/client/src/components/pages/myDemos/DemoItem.js
@@ -2,6 +2,7 @@ import { IconButton } from 'components/reusable/button/Button';
 import { ContributorSearch } from 'components/userSearch/ContributorSearch';
 import UserContext from 'context/UserContext';
 import React, { useContext, useState } from 'react';
+import Axios from 'axios';
 import { FaRegTrashAlt } from 'react-icons/fa';
 import { MdPersonAdd, MdSettings } from 'react-icons/md';
 import { useHistory } from 'react-router-dom';
@@ -19,6 +20,13 @@ export const DemoItem = ({demo, setDemos}) => {
             pathname: `/demos/${demo._id}`,
             state: { demo }
         });
+    }
+
+    const deleteDemo = (demo) => {
+        if (window.confirm(`Are you sure you want to delete your demo "${demo.title}" ?`)) {
+            Axios.delete(`/demos/${demo._id}`);
+            setDemos(demos => demos.filter(d => d._id !== demo._id));
+        }
     }
 
     const updateDemos = (updatedDemo) => {
@@ -41,7 +49,7 @@ export const DemoItem = ({demo, setDemos}) => {
 
             {/* only let the demo creator add users to a demo or delete a demo. might want to extend this to demo contributors in the future */}
             {user._id === demo.creator._id && <div className="demoItemControls">
-                <IconButton component={FaRegTrashAlt} />
+                <IconButton component={FaRegTrashAlt} onClick={() => deleteDemo(demo)} />
                 <IconButton component={MdPersonAdd} onClick={() => setShowSearch(show => !show)} style={{marginTop: "10px"}} />
                 <IconButton component={MdSettings} onClick={() => setShowSettings(show => !show)} style={{marginTop: "10px"}}/>
             </div>}

--- a/server/services/demo.service.js
+++ b/server/services/demo.service.js
@@ -75,18 +75,23 @@ const modifyTrackStartTime = (trackId, startTime) => {
     return Track.findByIdAndUpdate(trackId, { trackStart: startTime });
 }
 
-const deleteDemoById = (demoId) => {
+const deleteDemoById = async (demoId) => {
+    const demo = await Demo.findById(demoId);
+    const tracks = demo.tracks;
+
+    await tracks.forEach(track => deleteTrack(demoId, track._id));
+
     return Demo.findByIdAndDelete(demoId);
 }
 
 const deleteTrack = async (demoId, trackId) => {
-    const track = await Track.findByIdAndDelete(trackId);
-
-    Demo.findOneAndUpdate(
+    await Demo.findOneAndUpdate(
         { tracks: trackId },
         { $pull: { tracks: trackId } },
-        { new: true }
+        { new: true},
     );
+
+    const track = await Track.findByIdAndDelete(trackId);
 
     await s3.deleteFile(`${demoId}/${trackId}`);
 

--- a/server/services/demo.service.js
+++ b/server/services/demo.service.js
@@ -77,9 +77,11 @@ const modifyTrackStartTime = (trackId, startTime) => {
 
 const deleteDemoById = async (demoId) => {
     const demo = await Demo.findById(demoId);
-    const tracks = demo.tracks;
 
-    await tracks.forEach(track => deleteTrack(demoId, track._id));
+    demo.tracks.forEach(async track => {
+        await Track.findByIdAndDelete(track._id);
+        await s3.deleteFile(`${demoId}/${track._id}`);
+    });
 
     return Demo.findByIdAndDelete(demoId);
 }

--- a/server/services/demo.service.js
+++ b/server/services/demo.service.js
@@ -88,7 +88,7 @@ const deleteTrack = async (demoId, trackId) => {
     await Demo.findOneAndUpdate(
         { tracks: trackId },
         { $pull: { tracks: trackId } },
-        { new: true},
+        { new: true }
     );
 
     const track = await Track.findByIdAndDelete(trackId);


### PR DESCRIPTION
Closes #26 

Updated `deleteDemoById` service to delete tracks from AWS and the tracks collection before deleting the demo. Fixed small bug with the `deleteTrack` demo service where tracks would be stuck on a demo after they were deleted (all I did was reorder the demo update and track deletion).

Trashcan buttons now delete the demo in both my-demos and inside the demo itself.