### PR TITLE
Added Track Settings and Basic Start TIme Slider

### DIFF
--- a/client/src/components/pages/demo/track/StartTimeSlider.js
+++ b/client/src/components/pages/demo/track/StartTimeSlider.js
@@ -1,16 +1,13 @@
-import React, { useEffect, useRef, useState } from 'react';
+import axios from 'axios';
+import React, { useEffect, useRef } from 'react';
+import { FaMinus, FaPlus } from 'react-icons/fa';
 
-export const StartTimeSlider = ({track, demoLength, setTracks}) => {
+export const StartTimeSlider = ({track, demoLength, setTracks, startTimeState}) => {
 
-    const [ start, setStart ] = useState(0);
+    const [ start, setStart ] = startTimeState;
     const maxStart = track.player ? demoLength - track.player.buffer.duration : 0;
 
     const timeout = useRef(null);
-
-    // any time the track start changes, update the start
-    useEffect(() => {
-        setStart(track.trackStart);
-    }, [track.trackStart]);
 
     // clear the timeout on unmount
     useEffect(() => {
@@ -26,11 +23,12 @@ export const StartTimeSlider = ({track, demoLength, setTracks}) => {
         clearTimeout(timeout.current);
 
         timeout.current = setTimeout(() => {
-            console.log("It's been 1 second since we adjusted the start time");
-
             // if the track has a URL we know it has been uploaded to the database before
             if (track.trackSignedURL) {
-                console.log("Make an Axios request to update the track's trackStart so it persists across refresh");
+                axios.post(`/demos/modify-track-start-time`, {
+                    trackId: track._id,
+                    startTime: startValue
+                });
             }
         }, 1000);
 
@@ -50,12 +48,17 @@ export const StartTimeSlider = ({track, demoLength, setTracks}) => {
         track.player.unsync().stop().sync().start(newStart);
     }
 
-    return <div style={{padding: "10px", display: "flex", alignItems: "center", justifyContent: "center"}}>
-        {start !== null && <>
-            <input type="range" step={.001} min={0} max={maxStart} value={start} onChange={e => startChange(e.target.value)} />
-            <button onClick={() => startChange(start - .001)}>Minus 0.001</button>
-            <button onClick={() => startChange(start + .001)}>Plus 0.001</button>
-            <div>Start {start.toFixed(3)}</div>
-        </>}
+    // if the track has no startTime or the maxStart is 0 (meaning it can not be changed to anything since its stuck at 0)
+    if (start === null || maxStart <= 0) return null;
+
+    return <div className="startSliderContainer">
+        <button className="startSliderButton" onClick={() => startChange(start - .001)}>
+            <FaPlus />
+        </button>
+        <button className="startSliderButton" onClick={() => startChange(start + .001)}>
+            <FaMinus />
+        </button>
+        <input className="startSlider" type="range" step={.001} min={0} max={maxStart} value={start} onChange={e => startChange(e.target.value)} />
+        <div className="startSliderTime">{start.toFixed(3)}</div>
     </div>
 }

--- a/client/src/components/pages/demo/track/StartTimeSlider.js
+++ b/client/src/components/pages/demo/track/StartTimeSlider.js
@@ -1,0 +1,61 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+export const StartTimeSlider = ({track, demoLength, setTracks}) => {
+
+    const [ start, setStart ] = useState(0);
+    const maxStart = track.player ? demoLength - track.player.buffer.duration : 0;
+
+    const timeout = useRef(null);
+
+    // any time the track start changes, update the start
+    useEffect(() => {
+        setStart(track.trackStart);
+    }, [track.trackStart]);
+
+    // clear the timeout on unmount
+    useEffect(() => {
+        return () => clearTimeout(timeout);
+    }, []);
+
+    const startChange = (startValue) => {
+
+        // do nothing if the startValue is out of our acceptable range
+        // might want to change this in future to allow for moving the start before or after the demo to cut off some parts
+        if (startValue < 0 || startValue > demoLength) { return; }
+
+        clearTimeout(timeout.current);
+
+        timeout.current = setTimeout(() => {
+            console.log("It's been 1 second since we adjusted the start time");
+
+            // if the track has a URL we know it has been uploaded to the database before
+            if (track.trackSignedURL) {
+                console.log("Make an Axios request to update the track's trackStart so it persists across refresh");
+            }
+        }, 1000);
+
+        const newStart = parseFloat(startValue);
+
+        setStart(newStart);
+
+        // update the changed track
+        setTracks(tracks => tracks.map(t => {
+            if (t._id === track._id) {
+                return { ...t, trackStart: newStart };
+            }
+            return t;
+        }))
+
+        // update the player's start time to the new time. If we don't unsync we get an error trying to set a new start time
+        track.player.unsync().stop().sync().start(newStart);
+    }
+
+    return <div style={{padding: "10px", display: "flex", alignItems: "center", justifyContent: "center"}}>
+        {start !== null && <>
+            <input type="range" step={.001} min={0} max={maxStart} value={start} onChange={e => startChange(e.target.value)} />
+            <button onClick={() => startChange(start - .001)}>Minus 0.001</button>
+            <button onClick={() => startChange(start + .001)}>Plus 0.001</button>
+            <div>Start {start.toFixed(3)}</div>
+        </>}
+    </div>
+}

--- a/client/src/components/pages/demo/track/Track.js
+++ b/client/src/components/pages/demo/track/Track.js
@@ -26,7 +26,7 @@ export const Track = ({
 
   const [error, setError] = useState(null);
   const [hasAudio, setHasAudio] = useState(!!track.trackSignedURL);
-  const [startTime, setStartTime] = useState(null);
+  const [startTime, setStartTime] = useState(track.trackStart);
   const [recording, setRecording] = useState(false);
   const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
@@ -234,31 +234,36 @@ export const Track = ({
     <>
       <div className="trackContainer">
         <div className="trackTop">
+
           <div className="trackInfo">
             <h3 title={track.trackTitle}>{track.trackTitle}</h3>
             <div>{track.trackAuthor}</div>
           </div>
 
-          <div className="trackWaveContainer">
-            {track.player && 
-            <Waveform
-              track={track}
-              demoLength={demoLength}
-              timeState={[currentTime, setCurrentTime]}
-              playingState={[playing, setPlaying]}
-            />}
-            <div className="trackWaveButtonContainer">
-              <button onClick={deleteTrack} className="trackWaveButton">
-                <FaTimes />
-              </button>
-              <button onClick={() => setShowSettings(show => !show)} className="trackWaveButton">
-                <MdSettings />
-              </button>
+          <div className="trackRight">
+
+            <div className="trackWaveContainer">
+              {track.player && <Waveform
+                track={track}
+                demoLength={demoLength}
+                timeState={[currentTime, setCurrentTime]}
+                playingState={[playing, setPlaying]}
+                />}
+
+              <div className="trackWaveButtonContainer">
+                <button onClick={deleteTrack} className="trackWaveButton">
+                  <FaTimes />
+                </button>
+                <button onClick={() => setShowSettings(show => !show)} className="trackWaveButton">
+                  <MdSettings />
+                </button>
+              </div>
+              
             </div>
+            <StartTimeSlider track={track} demoLength={demoLength} setTracks={setTracks} startTimeState={[startTime, setStartTime]} />
           </div>
         </div>
 
-        <StartTimeSlider track={track} demoLength={demoLength} setTracks={setTracks} />
 
         <div className="trackControls">
           {/* recorder is null if the user does not allow recording in browser. don't let user click start if its null */}

--- a/client/src/components/pages/demo/track/Track.js
+++ b/client/src/components/pages/demo/track/Track.js
@@ -10,6 +10,7 @@ import MicRecorder from "mic-recorder-to-mp3";
 import { Waveform } from "./Waveform";
 import { TrackSettings } from "./TrackSettings";
 import { MdSettings } from "react-icons/md";
+import { StartTimeSlider } from "./StartTimeSlider";
 
 export const Track = ({
   track,
@@ -256,6 +257,8 @@ export const Track = ({
             </div>
           </div>
         </div>
+
+        <StartTimeSlider track={track} demoLength={demoLength} setTracks={setTracks} />
 
         <div className="trackControls">
           {/* recorder is null if the user does not allow recording in browser. don't let user click start if its null */}

--- a/client/src/components/pages/demo/track/Track.js
+++ b/client/src/components/pages/demo/track/Track.js
@@ -8,6 +8,8 @@ import { useParams } from "react-router-dom";
 import ErrorNotice from "components/reusable/error/Error";
 import MicRecorder from "mic-recorder-to-mp3";
 import { Waveform } from "./Waveform";
+import { TrackSettings } from "./TrackSettings";
+import { MdSettings } from "react-icons/md";
 
 export const Track = ({
   track,
@@ -30,6 +32,7 @@ export const Track = ({
   const [volume, setVolume] = useState(0);
   const [tracks, setTracks] = tracksState;
   const [playing, setPlaying] = playingState;
+  const [showSettings, setShowSettings] = useState(false);
 
   const recorder = useMemo(() => new MicRecorder({ bitRate: 128 }), []);
 
@@ -215,6 +218,17 @@ export const Track = ({
     }
   };
 
+  const onUpdateTrack = (updatedTrack) => {
+    setTracks(tracks => tracks.map(t => {
+      if (t._id === track._id) {
+          // spread the original track THEN the updatedOne so we only overwrite updated fields
+          // this makes sure we don't remove the track's audio player since a track fetched from the server won't have a player
+          return { ...t, ...updatedTrack };
+      }
+      return t;
+    }));
+  }
+
   return (
     <>
       <div className="trackContainer">
@@ -224,16 +238,22 @@ export const Track = ({
             <div>{track.trackAuthor}</div>
           </div>
 
-          <div className="trackWave">
-            {track.player ? <Waveform
-                              track={track}
-                              demoLength={demoLength}
-                              timeState={[currentTime, setCurrentTime]}
-                              playingState={[playing, setPlaying]}
-                            /> : null}
-            <button onClick={deleteTrack} className="deleteTrackButton">
-              <FaTimes />
-            </button>
+          <div className="trackWaveContainer">
+            {track.player && 
+            <Waveform
+              track={track}
+              demoLength={demoLength}
+              timeState={[currentTime, setCurrentTime]}
+              playingState={[playing, setPlaying]}
+            />}
+            <div className="trackWaveButtonContainer">
+              <button onClick={deleteTrack} className="trackWaveButton">
+                <FaTimes />
+              </button>
+              <button onClick={() => setShowSettings(show => !show)} className="trackWaveButton">
+                <MdSettings />
+              </button>
+            </div>
           </div>
         </div>
 
@@ -264,6 +284,8 @@ export const Track = ({
           <VolumeSlider value={volume} onChange={volumeChange} onMute={volumeMute} onMax={volumeMax} />
         </div>
       </div>
+
+      {showSettings && <TrackSettings track={track} onExit={() => setShowSettings(false)} onUpdateTrack={onUpdateTrack} />}
 
       {error && (
         <div style={{ padding: "0px 15px" }}>

--- a/client/src/components/pages/demo/track/TrackSettings.js
+++ b/client/src/components/pages/demo/track/TrackSettings.js
@@ -1,0 +1,65 @@
+import Axios from 'axios';
+import { Button } from 'components/reusable/button/Button';
+import { Form, FormInput } from 'components/reusable/form/Form';
+import { Popup } from 'components/reusable/popup/Popup';
+import React, { useEffect, useRef, useState } from 'react';
+
+export const TrackSettings = ({track, onExit, onUpdateTrack}) => {
+
+    console.log("TRACK", track);
+
+    const [ title, setTitle ] = useState(track.trackTitle);
+    const [ error, setError ] = useState(null);
+    const [ notice, setNotice ] = useState(null);
+    
+    const timeoutRef = useRef();
+
+    // useEffect that removes the error/notice after 4 seconds of appearing
+    useEffect(() => {
+        timeoutRef.current = setTimeout(() => {
+            setError(null);
+            setNotice(null);
+        }, 4000);
+
+        return () => clearTimeout(timeoutRef.current);
+    }, [error, notice]);
+   
+
+    const submit = async () => {
+        try {
+
+            if (!title) { return setError("Title is required"); }
+
+            if (title === track.trackTitle) {
+                return setError("You didn't change anything");
+            }
+
+            const { data: updatedTrack } = await Axios.put(`/demos/update-track/${track._id}`, {
+                title,
+            });
+
+            onUpdateTrack(updatedTrack);
+
+            setNotice("Successfully Updated Track");
+        } catch (err) {
+            err.response && setError(err.response.data.error);
+        }
+    }
+
+    return (
+        <Popup title={track.trackTitle} onExit={onExit}>
+            {error && <div>{error}</div>}
+            {notice && <div>{notice}</div>}
+            <Form onSubmit={submit}>
+                <FormInput name="title" label="Track Title" value={title} onChange={e => setTitle(e.target.value)} autoFocus />
+            
+                <FormInput name="author" label="Track Author" value={track.trackAuthor} readOnly/>
+                {track.trackStart !== null && <FormInput name="trackStart" label="Track Start Time" value={`${track.trackStart.toFixed(2)} seconds`} readOnly/>}
+
+                <div className="center">
+                    <Button type="submit">Submit Changes</Button>
+                </div>
+            </Form>
+        </Popup>
+    );
+}

--- a/client/src/components/pages/demo/track/TrackSettings.js
+++ b/client/src/components/pages/demo/track/TrackSettings.js
@@ -6,8 +6,6 @@ import React, { useEffect, useRef, useState } from 'react';
 
 export const TrackSettings = ({track, onExit, onUpdateTrack}) => {
 
-    console.log("TRACK", track);
-
     const [ title, setTitle ] = useState(track.trackTitle);
     const [ error, setError ] = useState(null);
     const [ notice, setNotice ] = useState(null);

--- a/client/src/components/pages/demo/track/Waveform.js
+++ b/client/src/components/pages/demo/track/Waveform.js
@@ -73,7 +73,7 @@ export const Waveform = ({
 
 
   return (
-    <div>
+    <div className="trackWaveform">
       {/* Scrubber is absolutely positioned over the waveform */}
       <Scrubber 
         timeState={[currentTime, setCurrentTime]}

--- a/client/src/components/pages/demo/track/track.css
+++ b/client/src/components/pages/demo/track/track.css
@@ -10,10 +10,12 @@
     display: flex;
 }
 
+.trackRight {
+    flex: 4;
+}
+
 .trackWaveContainer {
     background-color: lightgray;
-    padding: 0;
-    flex: 4;
     display: flex;
 }
 
@@ -131,4 +133,49 @@
     border-radius: 50%;
     background: gray;
     cursor: pointer;
+}
+
+/* Start Time Slider */
+.startSliderContainer {
+    padding: 0px;
+    display: flex;
+    background-color: lightgray;
+    border-top: 2px solid gray;
+}
+
+.startSlider {
+    flex: 1;
+    background-color: lightgray;
+}
+
+.startSlider::-moz-range-thumb,
+.startSlider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    border-radius: 0px;
+    height: 100%;
+    cursor: pointer;
+
+}
+
+.startSliderTime {
+    white-space: nowrap;
+    padding: 0px 3px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: small;
+    border-left: 2px solid gray;
+}
+
+.startSliderButton {
+    border: none;
+    background-color: inherit;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    font-size: small;
+    border-right: 2px solid gray;
+    padding: 4px;
 }

--- a/client/src/components/pages/demo/track/track.css
+++ b/client/src/components/pages/demo/track/track.css
@@ -10,11 +10,42 @@
     display: flex;
 }
 
-.trackWave {
+.trackWaveContainer {
     background-color: lightgray;
     padding: 0;
     flex: 4;
+    display: flex;
+}
+
+.trackWaveform {
     position: relative;
+    flex: 1;
+}
+
+.trackWaveButtonContainer {
+    border-left: 2px solid gray;
+    background-color: white;
+    margin-left: auto; /* so it goes all the way to the right side when there is no waveform */
+    z-index: 1; /* added z-index because the <RenderedWaveform> container overlaps otherwise */
+}
+
+.trackWaveButton {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    right: 10px;
+    width: 35px;
+    height: 35px;
+    border-radius: 50%;
+    border: 1px solid black;
+    cursor: pointer;
+    font-size: large;
+    background-color: lightgray;
+    margin: 10px 5px 0px 5px;
+}
+
+.trackWaveButton:last-of-type {
+    margin-bottom: 10px;
 }
 
 .trackInfo {
@@ -39,21 +70,6 @@
     padding: 10px;
 }
 
-.deleteTrackButton {
-    position: absolute;
-    z-index: 6;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    top: 10px;
-    right: 10px;
-    width: 35px;
-    height: 35px;
-    border-radius: 50%;
-    border: none;
-    cursor: pointer;
-    font-size: large;
-}
 
 /* temporary style so it looks a bit nicer */
 .trackControlButton {

--- a/server/routes/demo.router.js
+++ b/server/routes/demo.router.js
@@ -46,6 +46,13 @@ router.put("/:demoId/update", (req, res) => {
     respond(res, () => serv.updateDemo(demoId, title, isPublic));
 });
 
+router.put("/update-track/:trackId", (req, res) => {
+    const { trackId } = req.params;
+    const { title } = req.body;
+
+    respond(res, () => serv.updateTrack(trackId, title));
+});
+
 router.delete("/:demoId", (req, res) => {
     const { demoId } = req.params;
     respond(res, () => serv.deleteDemoById(demoId));

--- a/server/services/demo.service.js
+++ b/server/services/demo.service.js
@@ -144,6 +144,22 @@ const updateDemo = async (demoId, title, isPublic) => {
     return { ...demo, creator };
 }
 
+const updateTrack = async (trackId, title) => {
+
+    if (!title || !trackId) {
+        error("Track title and Id are required to update");
+    }
+
+    const updatedTrack = await Track.findByIdAndUpdate(trackId, 
+        { trackTitle: title }, 
+        { new: true} 
+    );
+
+    if (!updatedTrack) { error("Couldn't update track"); }
+
+    return updatedTrack.toObject();
+}
+
 // a helper function that gets demos, lets us pass in a custom mongo $match to filter
 const getDemos = (match) => {
 
@@ -194,5 +210,6 @@ module.exports = {
     deleteTrack,
     deleteTrackAudio,
     addUserToDemo,
-    updateDemo
+    updateDemo,
+    updateTrack
 }


### PR DESCRIPTION
Closes #13
Closes #39

# High Level Overview
Added a new button to each track on the right side below the exit button. This button brings up an popup just like the demo settings button. This popup shows three fields: the track title, track author, and conditionally the track start time if it exists. Only the track _title_ is editable. The other two fields are visible so the user can see them, but they have the `readOnly` attribute applied to their `<input>` element so they can not be edited.

# TrackSettings.js
Add a new file `TrackSettings.js`, which is very similar to `DemoSettings.js`. It handles the actual popup created by the settings button on each track. It might be wise to make a single `Settings` component to reuse for both, but the amount of code is low and we'd still have to write a unique `submit` function for each track/demo, which is a good bulk of the code.

# Back-end Changes
Added an `updateTrack` service function in the backend which just takes in a `trackId` and a new track title and updates the track with the given id to have the new title. This function could be expanded in the future to have more parameters to update more parts of a track. Also made a corresponding route for this function at `PUT /demos/update-track/:trackId`.

# CSS Changes
I had to change up the CSS a fair bit to accommodate the new button. I tried to make the new track settings button absolutely positioned like the delete track `X` button, but it overflowed its container and would have required a fair bit of ugly CSS. I think its best to avoid absolute positioning when possible. Instead, I made the wave form area the `.trackWaveContainer` and the `.trackWaveContainer` holds the `.trackWaveform` on the left side (canvas/scrubber stuff) and the `.trackWaveButtonContainer` on the right (delete/settings buttons). This allowed for way more dynamic CSS since the track height grew to accommodate the new button after removing the absolute positioning.

# Edit 2/11 - StartTimeSlider.js
Added a StartTimeSlider component that allows for manually adjustment of Track start times. The styling is temporary just to make it look decent. As the start time changes from the slider/buttons Axios requests are made to the server to save the updated `trackStart` time. These requests are made only 1 second no new start time changes have been made.

Currently, this slider lets the user adjust a track's start time in the range of `0 seconds` to `(demoLength - trackLength) seconds`. This means a user cannot set a track's start time before the demo start and the user cannot set a track's end time to be after the demo end. I think maybe the allowable end time should be updated to let the track overflow the demo length so the user could drag a track's start time all the way to the end of the demo length. However, that seemed a bit trickier to implement so I stuck with the simple version for now.
